### PR TITLE
Trivial Spelling correction

### DIFF
--- a/Destructuring/db-defmacro.lisp
+++ b/Destructuring/db-defmacro.lisp
@@ -8,7 +8,7 @@
 ;;;; arbitrary lambda list; only a trees of variables, similar to the
 ;;;; destructuring done by LOOP.  Also, DB does not destructure an
 ;;;; ordinary Common Lisp tree, and instead works on a concrete syntax
-;;;; tree.  Finally, DP takes an additional argument (the first one)
+;;;; tree.  Finally, DB takes an additional argument (the first one)
 ;;;; compared to DESTRUCTURING-BIND.  That argument is a variable that
 ;;;; will be bound to the SOURCE slot of the CST.
 

--- a/cons-cst.lisp
+++ b/cons-cst.lisp
@@ -60,7 +60,7 @@
 (defmethod seventh ((cst cons-cst))
   (nth 6 cst))
 
-(defmethod eigth ((cst cons-cst))
+(defmethod eighth ((cst cons-cst))
   (nth 7 cst))
 
 (defmethod ninth ((cst cons-cst))


### PR DESCRIPTION
eigth -> eighth

As `eigth` is not exported, this error was hopefully not relied on

Also typo DP -> DB