### PR TITLE
SEPARATE-{ORDINARY,FUNCTION}-BODY do not listify the returned body

### DIFF
--- a/body.lisp
+++ b/body.lisp
@@ -2,7 +2,7 @@
 
 (defmethod separate-ordinary-body ((body atom-cst))
   (assert (null body))
-  (values '() '()))
+  (values '() (make-instance 'atom-cst :raw nil)))
 
 (defmethod separate-ordinary-body ((body cons-cst))
   (loop with declarations = '()
@@ -11,12 +11,11 @@
                   (atom (first remaining))
                   (not (eq (raw (first (first remaining))) 'declare)))
         do (push (first remaining) declarations)
-        finally (return (values (reverse declarations)
-                                (listify remaining)))))
+        finally (return (values (reverse declarations) remaining))))
 
 (defmethod separate-function-body ((body atom-cst))
   (assert (null body))
-  (values '() nil '()))
+  (values '() nil (make-instance 'atom-cst :raw nil)))
 
 (defmethod separate-function-body ((body cons-cst))
   (loop with declarations = '()
@@ -36,4 +35,4 @@
                (push (first remaining) declarations))
         finally (return (values (reverse declarations)
                                 documentation
-                                (listify remaining)))))
+                                remaining))))

--- a/body.lisp
+++ b/body.lisp
@@ -16,7 +16,7 @@
 
 (defmethod separate-function-body ((body atom-cst))
   (assert (null body))
-  (values '() '()))
+  (values '() nil '()))
 
 (defmethod separate-function-body ((body cons-cst))
   (loop with declarations = '()

--- a/generic-functions.lisp
+++ b/generic-functions.lisp
@@ -39,21 +39,23 @@
 (defgeneric cstify (list))
 
 ;;; Given a body in the form of a CST that may contain declarations
-;;; but not a documentation string, return two values, a list of the
-;;; declarations and a list of the forms in the body.  Each return
-;;; value is an ordinary Common Lisp list, but the elements are CSTs.
+;;; but not a documentation string, return two values
+;;; 1) an ordinary Common Lisp list of CST instances representing the
+;;;    declarations
+;;; 2) a CST instance representing the forms in the body.
 ;;; It is assumed that the input has already been determined to be a
 ;;; proper list represented as a CST.
 (defgeneric separate-ordinary-body (body-cst))
 
 ;;; Given a body in the form of a CST that may contain both
-;;; declarations and a documentation string, return three values, a
-;;; list of the declarations, an ATOM-CST representing the
-;;; documentation string (or NIL if no documentation string is present
-;;; in the body) and a list of the forms in the body.  The first and
-;;; third return values are ordinary Common Lisp lists, but the
-;;; elements are CSTs.  It is assumed that the input has already been
-;;; determined to be a proper list represented as a CST.
+;;; declarations and a documentation string, return three values
+;;; 1) an ordinary Common Lisp list of CST instances representing the
+;;;    declarations
+;;; 2) an ATOM-CST representing the documentation string (or NIL if no
+;;;    documentation string is present in the body)
+;;; 3) a CST instance representing the forms in the body.
+;;; It is assumed that the input has already been determined to be a
+;;; proper list represented as a CST.
 (defgeneric separate-function-body (body-cst))
 
 ;;; Given a CST and an expression that is presumably some transformed

--- a/generic-functions.lisp
+++ b/generic-functions.lisp
@@ -48,11 +48,12 @@
 
 ;;; Given a body in the form of a CST that may contain both
 ;;; declarations and a documentation string, return three values, a
-;;; list of the declarations, a documentation string (or NIL if no
-;;; documentation string is present in the body) and a list of the
-;;; forms in the body.  Each return value is an ordinary Common Lisp
-;;; list, but the elements are CSTs.  It is assumed that the input has
-;;; already been determined to be a proper list represented as a CST.
+;;; list of the declarations, an ATOM-CST representing the
+;;; documentation string (or NIL if no documentation string is present
+;;; in the body) and a list of the forms in the body.  The first and
+;;; third return values are ordinary Common Lisp lists, but the
+;;; elements are CSTs.  It is assumed that the input has already been
+;;; determined to be a proper list represented as a CST.
 (defgeneric separate-function-body (body-cst))
 
 ;;; Given a CST and an expression that is presumably some transformed


### PR DESCRIPTION
**This is an incompatible change**, but I think it makes still makes sense since there are not too many clients yet.

The rationale for not listifying the returned body is that a client can trivially do that itself while a client that needs the CST representation of the body forms is currently out of luck.