### PR TITLE
Rewrite parse-macro to handle declarations

### DIFF
--- a/Destructuring/aux-parameters.lisp
+++ b/Destructuring/aux-parameters.lisp
@@ -1,33 +1,24 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod destructure-aux-parameter
-    (client (parameter aux-parameter) body)
+(defmethod aux-parameter-bindings
+    (client (parameter aux-parameter))
   (declare (ignore client))
-  (let ((name (name parameter))
+  (let ((name (raw (name parameter)))
         (form (form parameter)))
-    `(let ((,(raw name) ,(if (cl:null form) cl:nil (raw form))))
-       ,body)))
+    `((,name ,(if (cl:null form) cl:nil (raw form))))))
 
-(defmethod destructure-aux-parameters
-    (client (parameters cl:null) body)
+(defmethod aux-parameters-bindings
+    (client (parameters cl:null))
   (declare (ignore client))
-  body)
+  nil)
 
-(defmethod destructure-aux-parameters
-    (client (parameters cl:cons) body)
-  (destructure-aux-parameter
-   client
-   (car parameters)
-   (destructure-aux-parameters client (cdr parameters) body)))
-                                   
-(defmethod destructure-parameter-group
-    (client
-     (parameter-group aux-parameter-group)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-aux-parameters
-   client
-   (parameters parameter-group)
-   `(let ((,tail-variable ,argument-variable))
-      ,body)))
+(defmethod aux-parameters-bindings
+    (client (parameters cl:cons))
+  (loop for parameter in parameters
+        appending (aux-parameter-bindings client parameter)))
+
+(defmethod parameter-group-bindings
+    (client (parameter-group aux-parameter-group)
+     argument-variable)
+  (declare (ignore argument-variable))
+  (aux-parameters-bindings client (parameters parameter-group)))

--- a/Destructuring/generic-functions.lisp
+++ b/Destructuring/generic-functions.lisp
@@ -1,104 +1,60 @@
 (cl:in-package #:concrete-syntax-tree)
 
 ;;;; Generally speaking, these functions collectively take a macro
-;;;; lambda list and a BODY form, and wrap the body form in a bunch
-;;;; of LET bindings, for the purpose of creating a lambda expression
-;;;; corresponding to a macro function.
+;;;; lambda list and a variable, and return a list of LET* bindings
+;;;; that will bind the variables in that lambda list to the value
+;;;; in that variable.
 
-;;;; Every function defined here wraps a BODY form in some LET
-;;;; bindings.  These LET bindings are determined by the parameters of
-;;;; a lambda list.  Each function handles a different part of the
-;;;; lambda list.  CLIENT is some object representing the client.  It
-;;;; is used among other things to determine which condition class to
-;;;; use when a a condition needs to be signaled.  ARGUMENT-VARIABLE
+;;;; Each function rhandles a different part of the lambda list.
+;;;; CLIENT is some object representing the client. ARGUMENT-VARIABLE
 ;;;; is a symbol that, when the resulting macro function is executed
 ;;;; on some compound form corresponding to a macro call, will hold
 ;;;; the remaining part of the arguments of that macro call yet to be
-;;;; processed.
+;;;; processed. If the lambda list is nontrivial, the LET* bindings
+;;;; returned will repeatedly rebind this variable for the sake of
+;;;; later parts of the lambda list.
 
-;;;; Some functions have an argument called TAIL-VARIABLE, which is
-;;;; also a symbol that is going to be used in subsequent
-;;;; destructuring functions for the same purpose as
-;;;; ARGUMENT-VARIABLE.  Such a function is responsible for creating
-;;;; an innermost LET form that binds the TAIL-VARIABLE symbol to the
-;;;; part of the argument list that remains after the function has
-;;;; done its processing.  Some functions do not need such a variable,
-;;;; because they do not consume any arguments, so the remaining
-;;;; argument list is the same as the initial one.
+;;; Given an entire lambda list, which can be a macro lambda list or
+;;; a destructuring lambda list, return LET* bindings according to
+;;; the parameters of the lambda list.
+(defgeneric destructuring-lambda-list-bindings
+    (client lambda-list argument-variable))
 
-;;; Given an entire lambda list, which can be a macro lambda list or a
-;;; destructuring lambda list, Wrap BODY in a bunch of nested LET
-;;; bindings according to the parameters of the lambda list.
-(defgeneric destructure-lambda-list
-    (client lambda-list argument-variable tail-variable body))
+;;; Return LET* bindings corresponding to the parameters in the list
+;;; of parameter groups, PARAMETER-GROUPS.
+(defgeneric parameter-groups-bindings
+    (client parameter-groups argument-variable))
 
-;;; Wrap BODY in a LET form corresponding to a single &AUX parameter.
-;;; Since &AUX parameters are independent of the macro-call arguments,
-;;; there is no need for an ARGUMENT-VARIABLE.  The &AUX parameter
-;;; itself provides all the information required to determine the LET
-;;; binding.
-(defgeneric destructure-aux-parameter (client aux-parameter body))
+;;; Return LET* bindings for a single &AUX parameter. Since &AUX
+;;; parameters are independent of the macro-call arguments, there is
+;;; no need for an ARGUMENT-VARIABLE. The &AUX parameter itself
+;;; provides all the information required to determine the bindings.
+(defgeneric aux-parameter-bindings (client parameter))
 
-;;; Wrap BODY in nested LET forms, each corresponding to a single &AUX
-;;; parameter in the list of &AUX parameters PARAMETERS.  Since &AUX
-;;; parameters are independent of the macro-call argument, there is no
-;;; need for an ARGUMENT-VARIABLE.  Each &AUX parameter in PARAMETERS
-;;; itself provides all the information required to determine the LET
-;;; binding.
-(defgeneric destructure-aux-parameters (client parameters body))
+;;; Return LET* bindings for a list of &AUX parameters.
+(defgeneric aux-parameters-bindings (client parameters))
 
-;;; Wrap BODY in a LET form corresponding to a single &KEY parameter.
-(defgeneric destructure-key-parameter
-    (client key-parameter argument-variable body))
+;;; Return LET* bindings for a single &KEY parameter.
+(defgeneric key-parameter-bindings (client parameter argument-variable))
 
-;;; Wrap BODY in nested LET forms, each corresponding to a single &KEY
-;;; parameter in a list of such &KEY parameters.  Since &KEY
-;;; parameters do not consume any arguments, the list of arguments is
-;;; the same before and after the &KEY parameters have been processed.
-;;; As a consequence, we do not need a TAIL-VARIABLE for &KEY
-;;; parameters.
-(defgeneric destructure-key-parameters
-    (client parameters argument-variable body))
+;;; Return LET* bindings for a list of &KEY parameters.
+(defgeneric key-parameters-bindings (client parameters argument-variable))
 
-;;; Wrap body in a LET form corresponding to a &REST parameter.  Since
-;;; &REST parameters do not consume any arguments, the list of
-;;; arguments is the same before and after the &REST parameter has
-;;; been processed.  As a consequence, we do not need a TAIL-VARIABLE
-;;; for &REST parameters.
-(defgeneric destructure-rest-parameter
-    (client parameter argument-variable body))
+;;; Return LET* bindings for a &REST parameter.
+(defgeneric rest-parameter-bindings (client parameter argument-variable))
 
-;;; Wrap BODY in a LET form corresponding to a single &OPTIONAL
-;;; parameter.
-(defgeneric destructure-optional-parameter
-    (client optional-parameter argument-variable body))
+;;; Return LET* bindings for a single &OPTIONAL parameter.
+(defgeneric optional-parameter-bindings
+    (client parameter argument-variable))
 
-;;; Wrap BODY in nested LET forms, each corresponding to a single
-;;; &OPTIONAL parameter in a list of such &OPTIONAL parameters.  Since
-;;; every &OPTIONAL parameter DOES consume an argument, this function
-;;; does take a TAIL-VARIABLE argument as described above.
-(defgeneric destructure-optional-parameters
-    (client parameters argument-variable tail-variable body))
+;;; Return LET* bindings for a list of &OPTIONAL parameters.
+(defgeneric optional-parameters-bindings
+    (client parameters argument-variable))
 
-;;; Wrap BODY in one or more LET forms corresponding to a single
-;;; required parameter, depending on whether the required parameter is
-;;; a simple variable or a destructuring lambda list.
-(defgeneric destructure-required-parameter
-    (client parameter argument-variable body))
+;;; Return LET* bindings for a single required parameter.
+(defgeneric required-parameter-bindings
+    (client parameter argument-variable))
 
-;;; Wrap BODY in nested LET forms, corresponding to the list of
-;;; required parameters in the list of required parameters PARAMETERS.
-;;; Since every required parameter DOES consume an argument, this
-;;; function does take a TAIL-VARIABLE argument as described above.
-(defgeneric destructure-required-parameters
-    (client parameters argument-variable tail-variable body))
-
-;;; Wrap BODY in nested LET forms, corresponding to the parameters in
-;;; PARAMETER-GROUP.
-(defgeneric destructure-parameter-group
-    (client parameter-group argument-variable tail-variable body))
-
-;;; Wrap BODY in nested LET forms, corresponding to the parameters in
-;;; the list of parameter groups PARAMETER-GROUPS.
-(defgeneric destructure-parameter-groups
-    (client parameter-groups argument-variable tail-variable body))
+;;; Return LET* bindings for a list of required parameters.
+(defgeneric required-parameters-bindings
+    (client parameters argument-variable))

--- a/Destructuring/key-parameters.lisp
+++ b/Destructuring/key-parameters.lisp
@@ -1,7 +1,7 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod destructure-key-parameter
-    (client (parameter ordinary-key-parameter) argument-variable body)
+(defmethod key-parameter-bindings
+    (client (parameter ordinary-key-parameter) argument-variable)
   (declare (ignore client))
   (let* ((name (raw (name parameter)))
          (keyword (raw (keyword parameter)))
@@ -9,43 +9,32 @@
          (default-form (if (cl:null default-form-cst)
                            nil
                            (raw default-form-cst)))
-         (supplied-p-cst (supplied-p parameter))
+         (suppliedp-cst (supplied-p parameter))
+         (suppliedp-dummy (gensym "SUPPLIEDP"))
          (default-for-getf '(cl:list nil))
-         (default-var (gensym))
-         (form-variable (gensym)))
-    `(let* ((,default-var ,default-for-getf)
-            (,form-variable (getf ,argument-variable ,keyword ,default-var)))
-       (let ((,name (if (eq ,form-variable ,default-var)
-                        ,default-form
-                        ,form-variable))
-             ,@(if (cl:null supplied-p-cst)
-                   '()
-                   `((,(raw supplied-p-cst)
-                      (not (eq ,form-variable ,default-var))))))
-         ,body))))
+         (default-var (gensym "DEFAULT"))
+         (search-var (gensym "GETF")))
+    `((,default-var ,default-for-getf)
+      (,search-var (getf ,argument-variable ',keyword ,default-var))
+      (,suppliedp-dummy (not (eq ,search-var ,default-var)))
+      (,name (if ,suppliedp-dummy ,search-var ,default-form))
+      ;; we bind suppliedp after so that it's not bound during the
+      ;; execution of the default form.
+      ,@(unless (cl:null suppliedp-cst)
+          `((,(raw suppliedp-cst) ,suppliedp-dummy))))))
 
-(defmethod destructure-key-parameters
-    (client (parameters cl:null) argument-variable body)
-  (declare (ignore client))
-  body)
+(defmethod key-parameters-bindings
+    (client (parameters cl:null) argument-variable)
+  (declare (ignore client argument-variable))
+  nil)
 
-(defmethod destructure-key-parameters
-    (client (parameters cl:cons) argument-variable body)
-  (destructure-key-parameter
-   client
-   (car parameters)
-   argument-variable
-   (destructure-key-parameters client (cdr parameters) argument-variable body)))
+(defmethod key-parameters-bindings
+    (client (parameters cl:cons) argument-variable)
+  (loop for parameter in parameters
+        appending (key-parameter-bindings client parameter argument-variable)))
 
-(defmethod destructure-parameter-group
-    (client
-     (parameter-group ordinary-key-parameter-group)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-key-parameters
-   client
-   (parameters parameter-group)
-   argument-variable
-   `(let ((,tail-variable ,argument-variable))
-      ,body)))
+(defmethod parameter-group-bindings
+    (client (parameter-group ordinary-key-parameter-group)
+     argument-variable)
+  (key-parameters-bindings client (parameters parameter-group)
+                           argument-variable))

--- a/Destructuring/lambda-list.lisp
+++ b/Destructuring/lambda-list.lisp
@@ -1,48 +1,22 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod destructure-parameter-groups
-    (client (parameter-groups cl:null) argument-variable tail-variable body)
-  `(let ((,tail-variable ,argument-variable))
-     (declare (ignorable ,tail-variable))
-     ,body))
+(defmethod parameter-groups-bindings
+    (client (parameter-groups cl:null) argument-variable)
+  (declare (ignore client argument-variable))
+  nil)
 
-(defmethod destructure-parameter-groups
-    (client (parameter-groups cl:cons) argument-variable tail-variable body)
-  (let ((rest-variable (gensym)))
-    (destructure-parameter-group
-     client
-     (car parameter-groups)
-     argument-variable
-     rest-variable
-     (destructure-parameter-groups
-      client
-      (cdr parameter-groups)
-      rest-variable
-      tail-variable
-      body))))
+(defmethod parameter-groups-bindings
+    (client (parameter-groups cl:cons) argument-variable)
+  (loop for parameter-group in parameter-groups
+        appending (parameter-group-bindings client parameter-group
+                                            argument-variable)))
 
-(defmethod destructure-lambda-list
-    (client
-     (lambda-list macro-lambda-list)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-parameter-groups
-   client
-   (children lambda-list)
-   argument-variable
-   tail-variable
-   body))
+(defmethod destructuring-lambda-list-bindings
+    (client (lambda-list macro-lambda-list) argument-variable)
+  (parameter-groups-bindings client (children lambda-list)
+                             argument-variable))
 
-(defmethod destructure-lambda-list
-    (client
-     (lambda-list destructuring-lambda-list)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-parameter-groups
-   client
-   (children lambda-list)
-   argument-variable
-   tail-variable
-   body))
+(defmethod destructuring-lambda-list-bindings
+    (client (lambda-list destructuring-lambda-list) argument-variable)
+  (parameter-groups-bindings client (children lambda-list)
+                             argument-variable))

--- a/Destructuring/optional-parameters.lisp
+++ b/Destructuring/optional-parameters.lisp
@@ -1,53 +1,39 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod destructure-optional-parameter
-    (client (parameter ordinary-optional-parameter) argument-variable body)
+(defmethod optional-parameter-bindings
+    (client (parameter ordinary-optional-parameter) argument-variable)
   (declare (ignore client))
   (let* ((name (raw (name parameter)))
          (default-form-cst (form parameter))
          (default-form (if (cl:null default-form-cst)
                            nil
                            (raw default-form-cst)))
-         (supplied-p-cst (supplied-p parameter)))
-    `(let ((,name (if (cl:null ,argument-variable)
-                      ,default-form
-                      (car ,argument-variable)))
-           ,@(if (cl:null supplied-p-cst)
-                 '()
-                 `((,(raw supplied-p-cst))
-                   (not (cl:null ,argument-variable)))))
-       ,body)))
+         (suppliedp-cst (supplied-p parameter))
+         ;; the suppliedp is not bound for the default form, so we do this.
+         (suppliedp-dummy (gensym "SUPPLIEDP")))
+    `((,suppliedp-dummy (cl:consp ,argument-variable))
+      (,name (if ,suppliedp-dummy (cl:car ,argument-variable) ,default-form))
+      ,@(unless (cl:null suppliedp-cst)
+          `((,(raw suppliedp-cst) ,suppliedp-dummy)))
+      (,argument-variable (if ,suppliedp-dummy
+                              (cl:cdr ,argument-variable)
+                              ,argument-variable)))))
 
-(defmethod destructure-optional-parameters
-    (client (parameters cl:null) argument-variable tail-variable body)
-  (declare (ignore client))
-  `(let ((,tail-variable ,argument-variable))
-     ,body))
+;;; FIXME: destructuring optional parameters go here
 
-(defmethod destructure-optional-parameters
-    (client (parameters cl:cons) argument-variable tail-variable body)
-  (let ((rest-variable (gensym)))
-    (destructure-optional-parameter
-     client
-     (car parameters)
-     argument-variable
-     `(let ((,rest-variable (if (cl:null ,argument-variable)
-                                '()
-                                (cdr ,argument-variable))))
-        ,(destructure-optional-parameters client
-                                          (cdr parameters)
-                                          rest-variable
-                                          tail-variable
-                                          body)))))
+(defmethod optional-parameters-bindings
+    (client (parameters cl:null) argument-variable)
+  (declare (ignore client argument-variable))
+  nil)
 
-(defmethod destructure-parameter-group
-    (client
-     (parameter-group ordinary-optional-parameter-group)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-optional-parameters client
-                                   (parameters parameter-group)
-                                   argument-variable
-                                   tail-variable
-                                   body))
+(defmethod optional-parameters-bindings
+    (client (parameters cl:cons) argument-variable)
+  (loop for parameter in parameters
+        appending (optional-parameter-bindings client parameter
+                                               argument-variable)))
+
+(defmethod parameter-group-bindings
+    (client (parameter-group ordinary-optional-parameter-group)
+     argument-variable)
+  (optional-parameters-bindings client (parameters parameter-group)
+                                argument-variable))

--- a/Destructuring/required-parameters.lisp
+++ b/Destructuring/required-parameters.lisp
@@ -1,60 +1,38 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod destructure-required-parameter
-    (client (parameter simple-variable) argument-variable body)
-  `(if (cl:null ,argument-variable)
-       (error "too few arguments")
-       (let ((,(raw (name parameter)) (car ,argument-variable)))
-         ,body)))
+(defmethod required-parameter-bindings
+    (client (parameter simple-variable) argument-variable)
+  (declare (ignore client))
+  `((,(raw (name parameter))
+     (if (cl:consp ,argument-variable)
+         (car ,argument-variable)
+         (error "too few arguments")))
+    (,argument-variable (cl:cdr ,argument-variable))))
 
-(defmethod destructure-required-parameter
-    (client (parameter destructuring-lambda-list) argument-variable body)
-  (let ((new-argument-variable (gensym))
-        (tail-variable (gensym))
-        (temp (gensym)))
-    `(if (cl:null ,argument-variable)
-         (error "too few arguments")
-         (let ((,new-argument-variable (car ,argument-variable)))
-           ,(destructure-lambda-list
-             client
-             parameter
-             new-argument-variable
-             tail-variable
-             `(let ((,temp ,tail-variable))
-                (declare (ignore ,temp))
-                ,body))))))
+(defmethod required-parameter-bindings
+    (client (parameter destructuring-lambda-list) argument-variable)
+  (let ((new-argument-variable (gensym)))
+    `((,new-argument-variable
+       (if (cl:consp ,argument-variable)
+           (car ,argument-variable)
+           (error "too few arguments")))
+      ,@(destructuring-lambda-list-bindings client parameter
+                                            new-argument-variable)
+      (,argument-variable (cl:cdr ,argument-variable)))))
 
-(defmethod destructure-required-parameters
-    (client (parameters cl:null) argument-variable tail-variable body)
-  `(let ((,tail-variable ,argument-variable))
-     ,body))
+(defmethod required-parameters-bindings
+    (client (parameters cl:null) argument-variable)
+  (declare (ignore client argument-variable))
+  nil)
 
-(defmethod destructure-required-parameters
-    (client (parameters cl:cons) argument-variable tail-variable body)
-  (let ((rest-variable (gensym)))
-    (destructure-required-parameter
-     client
-     (car parameters)
-     argument-variable
-     `(let ((,rest-variable (if (cl:null ,argument-variable)
-                                '()
-                                (cdr ,argument-variable))))
-        ,(destructure-required-parameters
-          client
-          (cdr parameters)
-          rest-variable
-          tail-variable
-          body)))))
+(defmethod required-parameters-bindings
+    (client (parameters cl:cons) argument-variable)
+  `(,@(loop for parameter in parameters
+            appending (required-parameter-bindings client parameter
+                                                   argument-variable))))
 
-(defmethod destructure-parameter-group
-    (client
-     (parameter-group destructuring-required-parameter-group)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-required-parameters
-   client
-   (parameters parameter-group)
-   argument-variable
-   tail-variable
-   body))
+(defmethod parameter-group-bindings
+    (client (parameter-group destructuring-required-parameter-group)
+     argument-variable)
+  (required-parameters-bindings client (parameters parameter-group)
+                                argument-variable))

--- a/Destructuring/rest-parameters.lisp
+++ b/Destructuring/rest-parameters.lisp
@@ -1,32 +1,11 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod destructure-rest-parameter
-    (client (parameter simple-variable) argument-variable body)
-  `(let ((,(raw (name parameter)) ,argument-variable))
-     ,body))
+(defmethod rest-parameter-bindings
+    (client (parameter simple-variable) argument-variable)
+  `((,(raw (name parameter)) ,argument-variable)))
 
-(defmethod destructure-rest-parameter
-    (client (parameter destructuring-lambda-list) argument-variable body)
-  (let ((tail-variable (gensym))
-        (temp (gensym)))
-  (destructure-lambda-list
-   client
-   parameter
-   argument-variable
-   tail-variable
-   `(let ((,temp ,tail-variable))
-      (declare (ignore ,temp))
-      ,body))))
-
-(defmethod destructure-parameter-group
-    (client
-     (parameter-group destructuring-rest-parameter-group)
-     argument-variable
-     tail-variable
-     body)
-  (destructure-rest-parameter
-   client
-   (parameter parameter-group)
-   argument-variable
-   `(let ((,tail-variable ,argument-variable))
-      ,body)))
+(defmethod parameter-group-bindings
+    (client (parameter-group destructuring-rest-parameter-group)
+     argument-variable)
+  (rest-parameter-bindings client (parameter parameter-group)
+                           argument-variable))

--- a/packages.lisp
+++ b/packages.lisp
@@ -162,17 +162,17 @@
            #:*define-method-combination-lambda-list-grammar*
            #:*destructuring-lambda-list-grammar*
            #:*macro-lambda-list-grammar*
-           #:destructure-lambda-list
-           #:destructure-aux-parameter
-           #:destructure-aux-parameters
-           #:destructure-key-parameter
-           #:destructure-key-parameters
-           #:destructure-rest-parameter
-           #:destructure-optional-parameter
-           #:destructure-optional-parameters
-           #:destructure-required-parameter
-           #:destructure-required-parameters
-           #:destructure-parameter-group
+           #:destructuring-lambda-list-bindings
+           #:parameter-groups-bindings
+           #:aux-parameter-bindings
+           #:aux-parameters-bindings
+           #:key-parameter-bindings
+           #:key-parameters-bindings
+           #:rest-parameter-bindings
+           #:optional-parameter-bindings
+           #:optional-parameters-bindings
+           #:required-parameter-bindings
+           #:required-parameters-bindings)
            #:parse-macro
            #:db
            #:valid-binding-p

--- a/packages.lisp
+++ b/packages.lisp
@@ -172,7 +172,7 @@
            #:optional-parameter-bindings
            #:optional-parameters-bindings
            #:required-parameter-bindings
-           #:required-parameters-bindings)
+           #:required-parameters-bindings
            #:parse-macro
            #:db
            #:valid-binding-p


### PR DESCRIPTION
This turns the body of macro functions into basically a big `let*`, as discussed.

It changes the generic functions for destructuring parts of lambda lists.

It also changes `parse-macro` itself to accept a body (i.e. zero or more declarations followed by zero or more forms) instead of a form, so a corresponding change (one line) to Cleavir is required.

This solves a part of #16 but not most of it.