### PR TITLE
Remove parent slot from CSTs

### DIFF
--- a/Documentation/chap-basic-use.tex
+++ b/Documentation/chap-basic-use.tex
@@ -21,14 +21,6 @@ represented by \textit{cst} as provide by the
 initialization argument \texttt{:raw} when \textit{cst} was
 created.
 
-\Definitarg {:parent}
-
-This initialization argument is accepted by all subclasses of concrete
-syntax trees.  If the syntax tree is a top-level syntax tree, then
-\texttt{nil} should be provided as the value for this initialization
-argument.  Otherwise, the value should be the concrete syntax tree
-that is the parent of this one.
-
 \Definitarg {:source}
 
 This initialization argument is accepted by all subclasses of concrete
@@ -38,12 +30,6 @@ represented by this concrete syntax tree.  A value of \texttt{nil}
 indicates that the origin of the source code represented by this concrete
 syntax tree is unknown.  The default value (if this initialization
 argument is not provided) is \texttt{nil}.
-
-\Defgeneric {parent} {cst}
-
-This generic function returns the parent of \textit{cst} as provide by
-the initialization argument \texttt{:parent} when \textit{cst} was
-created.
 
 \Defgeneric {source} {cst}
 

--- a/Test/concrete-syntax-tree-test.asd
+++ b/Test/concrete-syntax-tree-test.asd
@@ -1,9 +1,0 @@
-(cl:in-package #:asdf-user)
-
-(defsystem concrete-syntax-tree-test
-  :depends-on (:concrete-syntax-tree)
-  :components
-  ((:file "packages")
-   (:file "random-expression")
-   (:file "cst-from-expression")
-   (:file "random-sources")))

--- a/concrete-syntax-tree.asd
+++ b/concrete-syntax-tree.asd
@@ -1,8 +1,17 @@
-(cl:in-package #:asdf-user)
-
-(defsystem :concrete-syntax-tree
+(defsystem "concrete-syntax-tree"
   :description "Library for parsing Common Lisp code into a concrete syntax tree."
   :author "Robert Strandh <robert.strandh@gmail.com>"
   :license "FreeBSD" ; See file LICENSE.text.
-  :depends-on (:concrete-syntax-tree-base
-               :concrete-syntax-tree-lambda-list))
+  :depends-on ("concrete-syntax-tree-base"
+               "concrete-syntax-tree-lambda-list")
+  :in-order-to ((test-op (test-op "concrete-syntax-tree/test"))))
+
+(defsystem "concrete-syntax-tree/test"
+  :depends-on ("concrete-syntax-tree")
+  :pathname "Test"
+  :components ((:file "packages")
+               (:file "random-expression")
+               (:file "cst-from-expression")
+               (:file "random-sources"))
+  :perform (test-op (operation component)
+             (uiop:symbol-call '#:concrete-syntax-tree-test '#:test-cst-from-expression)))

--- a/cons-cst.lisp
+++ b/cons-cst.lisp
@@ -18,14 +18,11 @@
   (raw cst))
 
 (defmethod cons (first rest &key source)
-  (let ((result (make-instance 'cons-cst
-                  :raw (cl:cons (raw-or-nil first) (raw-or-nil rest))
-                  :source source
-                  :first first
-                  :rest rest)))
-    (setf (parent first) result)
-    (setf (parent rest) result)
-    result))
+  (make-instance 'cons-cst
+                 :raw (cl:cons (raw-or-nil first) (raw-or-nil rest))
+                 :source source
+                 :first first
+                 :rest rest))
 
 (defun list (&rest csts)
   (loop for result = (make-instance 'atom-cst :raw nil) then (cons cst result)

--- a/cst.lisp
+++ b/cst.lisp
@@ -1,10 +1,7 @@
 (cl:in-package #:concrete-syntax-tree)
 
 (defclass cst ()
-  (;; This slot contains either another CST, namely the parent of this
-   ;; one, or NIL if this is a top-level CST.
-   (%parent :initarg :parent :accessor parent)
-   ;; This slot contains client-supplied information about the origin
+  (;; This slot contains client-supplied information about the origin
    ;; of this CST.
    (%source :initform nil :initarg :source :accessor source)
    ;; This slot contains the raw expression that this CST represents.

--- a/generic-functions.lisp
+++ b/generic-functions.lisp
@@ -4,10 +4,6 @@
 ;;; location is represented by a client-defined object.
 (defgeneric source (cst))
 
-;;; Return the parent of CST.  If CST does not have a parent, then NIL
-;;; is returned instead.
-(defgeneric parent (cst))
-
 ;;; Return true if and only if CST is an instance of NULL-CST.
 (defgeneric null (cst))
 

--- a/packages.lisp
+++ b/packages.lisp
@@ -33,7 +33,6 @@
   (:export #:cst
            #:cons-cst
            #:atom-cst
-           #:parent
            #:source
            #:first
            #:second


### PR DESCRIPTION
The slot has never been used by clients or the library and wasn't populated consistently anyway.