### PR TITLE
Declarations

### DIFF
--- a/declarations.lisp
+++ b/declarations.lisp
@@ -68,6 +68,8 @@
         until (null remaining)
         collect (list declaration-identifier-cst type (first remaining))))
 
+;;; IGNORE-DECLS is a list of symbols. These symbols are declaration identifiers
+;;; that CST should ignore, i.e., these declarations will be canonicalized as NIL.
 (defun canonicalize-declaration-specifiers (system ignore-decls declaration-specifiers)
   (reduce #'append
           (mapcar (lambda (specifier)


### PR DESCRIPTION
Handling type declarations and proclaim declaration better, as discussed. Adds one parameter to the declaration canonicalization functions. Do not merge this without the corresponding SICL PR (https://github.com/robert-strandh/SICL/pull/144)

Fixes #19 