### PR TITLE
Improve handling of grammars in terms of speed and interface.

### DIFF
--- a/Documentation/chap-lambda-list.tex
+++ b/Documentation/chap-lambda-list.tex
@@ -905,63 +905,55 @@ one such occurrence is present after parsing is complete.
 
 In order to have a grammar that is possible to use for parsing a
 lambda list, in addition to the rules for all the lambda list types
-and its components, a special rule for the grammar symbol
-\texttt{target} is required.  A different rule for this grammar symbol
-is added to the grammar, according to the particular lambda-list type
+and its components, a target rule is required to initialize a grammar
+object with \texttt{generate-grammar}, which the parser ultimately
+uses. The target is in accordance to the particular lambda-list type
 that is desired.
 
 \Defvar {*standard-grammar*}
 
-This variable contains all the standard grammar rules, excluding a
-rule for the grammar symbol \texttt{target}.
+This variable contains all the standard grammar rules in description
+form.
 
 \Defvar {*ordinary-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{ordinary-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{ordinary-lambda-list-grammar}.
 
 \Defvar {*generic-function-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{generic-function-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{generic-function-lambda-list}.
 
 \Defvar {*specialized-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{specialized-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{specialized-lambda-list}.
 
 \Defvar {*defsetf-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{defsetf-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{defsetf-lambda-list}.
 
 \Defvar {*define-modify-macro-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{define-modify-macro-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{define-modify-macro-lambda-list}.
 
 \Defvar {*define-method-combination-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{define-method-combination-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{define-method-combination-lambda-list}.
 
 \Defvar {*destructuring-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{destructuring-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{destructuring-lambda-list}.
 
 \Defvar {*macro-lambda-list-grammar*}
 
-This variable contains all the standard grammar rules, plus a rule
-with \texttt{target} on its left-hand side and
-\texttt{macro-lambda-list} as its right-hand side.
+This variable contains a grammar object with all the standard grammar
+rules, with target \texttt{macro-lambda-list}.
 
 \section{Parsers for standard lambda lists}
 

--- a/Lambda-list/Test/test.lisp
+++ b/Lambda-list/Test/test.lisp
@@ -7,7 +7,7 @@
 
 (defun test-ordinary (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*ordinary-lambda-list-grammar*
+              :grammar cst:*ordinary-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list (make-instance 'cst:ordinary-lambda-list)
               :client nil)))
@@ -17,7 +17,7 @@
 
 (defun test-generic-function (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*generic-function-lambda-list-grammar*
+              :grammar cst:*generic-function-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:generic-function-lambda-list)
@@ -29,7 +29,7 @@
 
 (defun test-specialized (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*specialized-lambda-list-grammar*
+              :grammar cst:*specialized-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:specialized-lambda-list)
@@ -41,7 +41,7 @@
 
 (defun test-defsetf (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*defsetf-lambda-list-grammar*
+              :grammar cst:*defsetf-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:defsetf-lambda-list)
@@ -53,7 +53,7 @@
 
 (defun test-define-modify-macro (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*define-modify-macro-lambda-list-grammar*
+              :grammar cst:*define-modify-macro-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:define-modify-macro-lambda-list)
@@ -65,7 +65,7 @@
 
 (defun test-define-method-combination (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*define-method-combination-lambda-list-grammar*
+              :grammar cst:*define-method-combination-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:define-method-combination-lambda-list)
@@ -77,7 +77,7 @@
 
 (defun test-destructuring (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*destructuring-lambda-list-grammar*
+              :grammar cst:*destructuring-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:destructuring-lambda-list)
@@ -89,7 +89,7 @@
 
 (defun test-macro (lambda-list)
   (let* ((p (make-instance 'cst:parser
-              :rules cst:*macro-lambda-list-grammar*
+              :grammar cst:*macro-lambda-list-grammar*
               :input (cst:cst-from-expression lambda-list)
               :lambda-list
               (make-instance 'cst:macro-lambda-list)

--- a/Lambda-list/grammar.lisp
+++ b/Lambda-list/grammar.lisp
@@ -18,7 +18,8 @@
             append (extract-symbols element))))
 
 (defclass grammar ()
-  ((%rules :initarg :rules :reader rules)))
+  ((%target-rule :initarg :target-rule :reader target-rule)
+   (%rules :initarg :rules :reader rules)))
 
 (defun compute-all-symbols (grammar)
   (let ((symbols (make-hash-table :test #'eq)))
@@ -33,11 +34,13 @@
   (and (cl:consp right-hand-side-element)
        (member (car right-hand-side-element) '(? *) :test #'eq)))
 
-(defmethod initialize-instance :after ((object grammar) &key rules)
-  (let ((new-rules (loop for rule in rules
-                         collect (make-instance 'rule
-                                   :left-hand-side (car rule)
-                                   :right-hand-side (cddr rule)))))
-    (reinitialize-instance
-     object
-     :rules new-rules)))
+(defun generate-grammar (target-rule rules)
+  (make-instance 'grammar
+                 :target-rule (make-instance 'rule
+                                             :left-hand-side 'target
+                                             :right-hand-side (cl:list target-rule))
+                 :rules (mapcar (lambda (rule)
+                                  (make-instance 'rule
+                                                 :left-hand-side (car rule)
+                                                 :right-hand-side (cddr rule)))
+                                rules)))

--- a/Lambda-list/grammar.lisp
+++ b/Lambda-list/grammar.lisp
@@ -11,24 +11,9 @@
           do (format stream "~s " symbol))
     (terpri stream)))
 
-(defun extract-symbols (right-hand-side-element)
-  (if (symbolp right-hand-side-element)
-      (list right-hand-side-element)
-      (loop for element in (cdr right-hand-side-element)
-            append (extract-symbols element))))
-
 (defclass grammar ()
   ((%target-rule :initarg :target-rule :reader target-rule)
    (%rules :initarg :rules :reader rules)))
-
-(defun compute-all-symbols (grammar)
-  (let ((symbols (make-hash-table :test #'eq)))
-    (loop for rule in (rules grammar)
-          do (setf (gethash (left-hand-side rule) symbols) t)
-             (loop for element in (right-hand-side rule)
-                   do (loop for symbol in (extract-symbols element)
-                            do (setf (gethash symbol symbols) t))))
-    symbols))
 
 (defun nullable-p (right-hand-side-element)
   (and (cl:consp right-hand-side-element)

--- a/Lambda-list/grammar.lisp
+++ b/Lambda-list/grammar.lisp
@@ -25,18 +25,21 @@
 ;;; called at grammar generation time.
 (defun generate-grammar (target grammar-description)
   (let ((relevant-rule-descriptions '())
-        (relevant-symbols (cl:list target)))
+        (relevant-symbols (cl:list target))
+        (seen-symbols '()))
     (loop (unless relevant-symbols
             (return))
-          (let* ((symbol (cl:pop relevant-symbols))
-                 (description (find symbol grammar-description :key #'car)))
-            (when description
-              (push description relevant-rule-descriptions)
-              (dolist (item (cddr description))
-                (pushnew (if (symbolp item)
-                             item
-                             (cl:second item))
-                         relevant-symbols)))))
+          (let ((symbol (cl:pop relevant-symbols)))
+            (unless (member symbol seen-symbols)
+              (dolist (description grammar-description)
+                (when (eq (car description) symbol)
+                  (push description relevant-rule-descriptions)
+                  (dolist (item (cddr description))
+                    (push symbol seen-symbols)
+                    (push (if (symbolp item)
+                              item
+                              (cl:second item))
+                          relevant-symbols)))))))
     (make-instance 'grammar
                    :target-rule (make-instance 'rule
                                                :left-hand-side 'target

--- a/Lambda-list/parse-top-levels.lisp
+++ b/Lambda-list/parse-top-levels.lisp
@@ -1,8 +1,8 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defun parse-top-level (client rules class lambda-list &key (error-p t))
+(defun parse-top-level (client grammar class lambda-list &key (error-p t))
   (let ((p (make-instance 'cst::parser
-             :rules rules
+             :grammar grammar
              :input lambda-list
              :lambda-list (make-instance class)
              :client client)))

--- a/Lambda-list/parser.lisp
+++ b/Lambda-list/parser.lisp
@@ -9,11 +9,10 @@
    (%remaining-states :initarg :states :accessor remaining-states)
    (%remaining-input :initarg :input :accessor remaining-input)))
 
-(defmethod initialize-instance :after ((object parser) &key rules)
+(defmethod initialize-instance :after ((object parser) &key)
   (let* ((states (loop repeat (1+ (length (raw (all-input object))))
                        collect (make-instance 'earley-state)))
-         (grammar (make-instance 'grammar :rules rules))
-         (target-rule (find 'target (rules grammar) :key #'left-hand-side))
+         (target-rule (target-rule (grammar object)))
          (item (make-instance 'earley-item
                  :parse-trees '()
                  :origin (car states)
@@ -22,8 +21,7 @@
     (push item (items (car states)))
     (reinitialize-instance
      object
-     :states states
-     :grammar grammar)))
+     :states states)))
 
 (defun find-final-item (parser)
   (let ((initial-state (car (all-states parser)))

--- a/Lambda-list/standard-grammars.lisp
+++ b/Lambda-list/standard-grammars.lisp
@@ -168,25 +168,25 @@
           *macro-lambda-list*))
 
 (defparameter *ordinary-lambda-list-grammar*
-  (cl:cons '(target <- ordinary-lambda-list) *standard-grammar*))
+  (generate-grammar 'ordinary-lambda-list *standard-grammar*))
 
 (defparameter *generic-function-lambda-list-grammar*
-  (cl:cons '(target <- generic-function-lambda-list) *standard-grammar*))
+  (generate-grammar 'generic-function-lambda-list *standard-grammar*))
 
 (defparameter *specialized-lambda-list-grammar*
-  (cl:cons '(target <- specialized-lambda-list) *standard-grammar*))
+  (generate-grammar 'specialized-lambda-list *standard-grammar*))
 
 (defparameter *defsetf-lambda-list-grammar*
-  (cl:cons '(target <- defsetf-lambda-list) *standard-grammar*))
+  (generate-grammar 'defsetf-lambda-list *standard-grammar*))
 
 (defparameter *define-modify-macro-lambda-list-grammar*
-  (cl:cons '(target <- define-modify-macro-lambda-list) *standard-grammar*))
+  (generate-grammar 'define-modify-macro-lambda-list *standard-grammar*))
 
 (defparameter *define-method-combination-lambda-list-grammar*
-  (cl:cons '(target <- define-method-combination-lambda-list) *standard-grammar*))
+  (generate-grammar 'define-method-combination-lambda-list *standard-grammar*))
 
 (defparameter *destructuring-lambda-list-grammar*
-  (cl:cons '(target <- destructuring-lambda-list) *standard-grammar*))
+  (generate-grammar 'destructuring-lambda-list *standard-grammar*))
 
 (defparameter *macro-lambda-list-grammar*
-  (cl:cons '(target <- macro-lambda-list) *standard-grammar*))
+  (generate-grammar 'macro-lambda-list *standard-grammar*))


### PR DESCRIPTION
This change proposes to change the interface to the grammar objects for lambda-list-parsing by introducing a function called `generate-grammar` to produce the grammar objects from rule descriptions. This has a few advantages:

- It encodes the constraint that there can only be one target rule, and this target rule needs to exist for lambda-list-parsing to work.
- It makes it so that instead of consing the *exact same* 6 * 21 grammar objects on every invocation of a lambda-list parse, the grammar object is precomputed into the lambda-list-grammar variables.
- Separating out grammar descriptions from the grammars themselves allow us to prune the grammar rules at grammar generation time. For example, there are only 5 ordinary lambda list rules that actually apply for any given parse of an ordinary lambda list. There is no point in searching the other 15 in the standard grammar on every state step of a parse. This change cuts the time to parse of an ordinary lambda list in half on SBCL.