### PR TITLE
Save some space and time while reconstructing.

### DIFF
--- a/Test/reconstruct.lisp
+++ b/Test/reconstruct.lisp
@@ -5,3 +5,9 @@
                             (make-instance 'cst:atom-cst :raw nil))))
     (setf (slot-value circular 'cst::%first) circular)
     (cst:reconstruct '#1=(#1#) circular nil)))
+
+(defun test-reconstruct-1 ()
+  (let* ((cons (cons 'a 'c))
+         (thing (cst:cst-from-expression cons)))
+    (eq (cst:first (cst:rest (cst:reconstruct (list 'b cons) thing nil)))
+        thing)))


### PR DESCRIPTION
A small algorithmic improvement in CST reconstruction reduced total consing for compilation of asdf on clasp by more than 3%. Macroexpansions which do not differ much from the original form benefit greatly.