### PR TITLE
Add destructuring for &whole parameters

### DIFF
--- a/Destructuring/concrete-syntax-tree-destructuring.asd
+++ b/Destructuring/concrete-syntax-tree-destructuring.asd
@@ -6,6 +6,7 @@
   :components
   ((:file "generic-functions")
    (:file "conditions")
+   (:file "whole-parameters")
    (:file "required-parameters")
    (:file "optional-parameters")
    (:file "rest-parameters")

--- a/Destructuring/generic-functions.lisp
+++ b/Destructuring/generic-functions.lisp
@@ -62,3 +62,6 @@
 ;;; Return LET* bindings for a list of required parameters.
 (defgeneric required-parameters-bindings
     (client parameters argument-variable))
+
+;;; Return LET* bindings for a &WHOLE parameter.
+(defgeneric whole-parameter-bindings (client parameter argument-variable))

--- a/Destructuring/whole-parameters.lisp
+++ b/Destructuring/whole-parameters.lisp
@@ -1,0 +1,15 @@
+(cl:in-package #:concrete-syntax-tree)
+
+(defmethod whole-parameter-bindings
+    (client (parameter simple-variable) argument-variable)
+  `((,(raw (name parameter)) ,argument-variable)))
+
+(defmethod whole-parameter-bindings
+    (client (parameter destructuring-lambda-list) argument-variable)
+  (destructuring-lambda-list-bindings client parameter argument-variable))
+
+(defmethod parameter-group-bindings
+    (client (parameter-group whole-parameter-group)
+     argument-variable)
+  (whole-parameter-bindings client (parameter parameter-group)
+                            argument-variable))

--- a/packages.lisp
+++ b/packages.lisp
@@ -179,6 +179,7 @@
            #:optional-parameters-bindings
            #:required-parameter-bindings
            #:required-parameters-bindings
+           #:whole-parameter-bindings
            #:parse-macro
            #:db
            #:valid-binding-p


### PR DESCRIPTION
Fixes #23.

We still have to remove any top-level &whole in parse-macro, because
the top level one behaves differently due to including the head of the
macro form.