### PR TITLE
Improve reporting of errors during destructuring

### DIFF
--- a/Destructuring/concrete-syntax-tree-destructuring.asd
+++ b/Destructuring/concrete-syntax-tree-destructuring.asd
@@ -4,9 +4,11 @@
   :depends-on (:concrete-syntax-tree-lambda-list)
   :serial t
   :components
-  ((:file "generic-functions")
+  ((:file "variables")
+   (:file "generic-functions")
    (:file "conditions")
    (:file "whole-parameters")
+   (:file "condition-generation")
    (:file "required-parameters")
    (:file "optional-parameters")
    (:file "rest-parameters")

--- a/Destructuring/condition-generation.lisp
+++ b/Destructuring/condition-generation.lisp
@@ -1,0 +1,70 @@
+(cl:in-package #:concrete-syntax-tree)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Generic functions
+;;;
+;;; These are called by parse-macro, destructuring-lambda-list-bindings, etc.
+;;; to produce code to report errors at runtime, i.e. when the lambda list does
+;;; not match the given arguments. Methods on these functions should return
+;;; forms that will signal the appropriate kind of error at runtime.
+;;; These forms must not return normally.
+
+(defgeneric too-many-arguments-error (client lambda-list
+                                      argument-variable macro-name))
+
+(defgeneric too-few-arguments-error (client lambda-list
+                                     argument-variable macro-name))
+
+(defgeneric odd-keywords-error
+    (client lambda-list argument-variable macro-name))
+
+(defgeneric unknown-keywords-error
+    (client lambda-list argument-variable unknown-keywords macro-name))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Default methods
+
+(defmethod too-many-arguments-error (client lambda-list
+                                     argument-variable macro-name)
+  (if (cl:null macro-name)
+      `(error "Too many elements in~%~2t~a~%to satisfy lambda list~%~2t~a"
+              ,argument-variable ',(unparse-lambda-list client lambda-list))
+      `(error "Error while parsing arguments to ~a:
+~2tToo many elements in~4t~a~%~2tto satisfy lambda list~%~4t~a"
+          ',macro-name ,argument-variable
+          ',(unparse-lambda-list client lambda-list))))
+
+(defmethod too-few-arguments-error (client lambda-list
+                                     argument-variable macro-name)
+  (if (cl:null macro-name)
+      `(error "Too few elements in~%~2t~a~%to satisfy lambda list~%~2t~a"
+              ,argument-variable ',(unparse-lambda-list client lambda-list))
+      `(error "Error while parsing arguments to ~a:
+~2tToo few elements in~4t~a~%~2tto satisfy lambda list~%~4t~a"
+          ',macro-name ,argument-variable
+          ',(unparse-lambda-list client lambda-list))))
+
+(defmethod odd-keywords-error (client lambda-list
+                               argument-variable macro-name)
+  (if (cl:null macro-name)
+      `(error "The keyword portion of ~a has an odd length, where keywords were expected:~%~2t~a"
+              ,argument-variable
+              ',(unparse-lambda-list client lambda-list))
+      `(error "Error while parsing arguments to ~a:
+~2tThe keyword portion of ~a has an odd length, where keywords were expected:~%~4t~a"
+              ',macro-name
+              ,argument-variable
+              ',(unparse-lambda-list client lambda-list))))
+
+(defmethod unknown-keywords-error (client lambda-list
+                                   argument-variable unknowns macro-name)
+  (if (cl:null macro-name)
+      `(error "Unknown keywords ~a in~%~2t~a~%for lambda list~%~2t~a"
+              ,unknowns ,argument-variable
+              ',(unparse-lambda-list client lambda-list))
+      `(error "Error while parsing arguments to ~a:
+~2tUnknown keywords ~a in~%~4t~a~%~2tfor lambda list~%~4t~a"
+              ',macro-name ,unknowns ,argument-variable
+              ',(unparse-lambda-list client lambda-list))))

--- a/Destructuring/generic-functions.lisp
+++ b/Destructuring/generic-functions.lisp
@@ -1,11 +1,10 @@
 (cl:in-package #:concrete-syntax-tree)
 
 ;;;; Generally speaking, these functions collectively take a macro
-;;;; lambda list and a variable, and return a list of LET* bindings
-;;;; that will bind the variables in that lambda list to the value
-;;;; in that variable as their first value, and a list of variables
-;;;; bound in the bindings that need to be declared IGNORABLE as a
-;;;; second value.
+;;;; lambda list or portion thereof, and a variable, and return two
+;;;; values: a list of LET* bindings that will bind the variables in
+;;;; that lambda list to the value in that variable, and a list of
+;;;; variables bound in the bindings that need to be declared IGNORABLE.
 
 ;;;; Each function handles a different part of the lambda list.
 ;;;; CLIENT is some object representing the client. ARGUMENT-VARIABLE
@@ -24,8 +23,6 @@
 
 ;;; Return LET* bindings corresponding to the parameters in the list
 ;;; of parameter groups, PARAMETER-GROUPS.
-;;; As a second variable, return a list of any variables that need
-;;; to be declared IGNORABLE.
 (defgeneric parameter-groups-bindings
     (client parameter-groups argument-variable))
 
@@ -43,6 +40,9 @@
 
 ;;; Return LET* bindings for a list of &KEY parameters.
 (defgeneric key-parameters-bindings (client parameters argument-variable))
+
+;;; Return LET* bindings for validating a &KEY parameter group.
+(defgeneric key-validation-bindings (client parameter-group argument-variable))
 
 ;;; Return LET* bindings for a &REST parameter.
 (defgeneric rest-parameter-bindings (client parameter argument-variable))

--- a/Destructuring/key-parameters.lisp
+++ b/Destructuring/key-parameters.lisp
@@ -69,11 +69,11 @@
 
 (defmethod key-validation-bindings
     (client (parameter-group key-parameter-group) argument-variable)
-  (declare (ignore client))
   (let ((glength-check (gensym "LENGTH-CHECK-DUMMY"))
         (length-check-form
           `(unless (evenp (cl:length ,argument-variable))
-             (error "odd number of keyword parameters"))))
+             ,(odd-keywords-error client *current-lambda-list*
+                                  argument-variable *current-macro-name*))))
     (if (allow-other-keys parameter-group)
         (values `((,glength-check ,length-check-form)) `(,glength-check))
         (let* ((unknowns (gensym "UNKNOWN-KEYWORDS"))
@@ -98,7 +98,9 @@
                (unknown-check (gensym "UNKNOWN-KEYWORDS-DUMMY"))
                (unknown-check-form
                  `(unless (cl:null ,unknowns)
-                    (error "unknown keywords ~a" ,unknowns))))
+                    ,(unknown-keywords-error client *current-lambda-list*
+                                             argument-variable unknowns
+                                             *current-macro-name*))))
           (values `((,glength-check ,length-check-form)
                     (,unknowns ,unknowns-form)
                     (,unknown-check ,unknown-check-form))

--- a/Destructuring/parse-macro.lisp
+++ b/Destructuring/parse-macro.lisp
@@ -18,6 +18,9 @@
 (defun parse-macro (client name lambda-list body &optional environment)
   (declare (ignore environment)) ; For now.
   (let* ((parsed-lambda-list (parse-macro-lambda-list client lambda-list))
+         (*current-lambda-list* parsed-lambda-list)
+         (raw-name (raw name))
+         (*current-macro-name* raw-name) 
 	 (env-var (find-var parsed-lambda-list 'environment-parameter-group))
 	 (final-env-var (if (cl:null env-var) (gensym "ENV") env-var))
 	 (form-var (find-var parsed-lambda-list 'whole-parameter-group))
@@ -34,7 +37,7 @@
         (destructuring-lambda-list-bindings
          client relevant-lambda-list args-var)
       `(lambda (,final-form-var ,final-env-var)
-         (block ,(raw name)
+         (block ,raw-name
            (let* ((,args-var (cdr ,final-form-var))
                   ,@bindings
                   ;; We rebind the whole and environment variables

--- a/Destructuring/required-parameters.lisp
+++ b/Destructuring/required-parameters.lisp
@@ -2,11 +2,11 @@
 
 (defmethod required-parameter-bindings
     (client (parameter simple-variable) argument-variable)
-  (declare (ignore client))
   `((,(raw (name parameter))
      (if (cl:consp ,argument-variable)
          (car ,argument-variable)
-         (error "too few arguments")))
+         ,(too-few-arguments-error client *current-lambda-list*
+                                   argument-variable *current-macro-name*)))
     (,argument-variable (cl:cdr ,argument-variable))))
 
 (defmethod required-parameter-bindings
@@ -19,7 +19,9 @@
        `((,new-argument-variable
           (if (cl:consp ,argument-variable)
               (car ,argument-variable)
-              (error "too few arguments")))
+              ,(too-few-arguments-error client *current-lambda-list*
+                                        argument-variable
+                                        *current-macro-name*)))
          ,@d-l-l-bindings
          (,argument-variable (cl:cdr ,argument-variable)))
        d-l-l-ignorables))))

--- a/Destructuring/variables.lisp
+++ b/Destructuring/variables.lisp
@@ -1,0 +1,10 @@
+(cl:in-package #:concrete-syntax-tree)
+
+;;; This variable is used internally to maintain a reference to a lambda list
+;;; that bindings are being generated for. It is used in error reporting.
+(defvar *current-lambda-list*)
+
+;;; This variable is used internally to maintain a reference to the name of a
+;;; macro for which a lambda list is being parsed, for error reporting.
+;;; If no macro is being parsed, its value is NIL.
+(defvar *current-macro-name* nil)

--- a/Lambda-list/concrete-syntax-tree-lambda-list.asd
+++ b/Lambda-list/concrete-syntax-tree-lambda-list.asd
@@ -15,4 +15,5 @@
    (:file "parser")
    (:file "scanner-action")
    (:file "earley")
-   (:file "parse-top-levels")))
+   (:file "parse-top-levels")
+   (:file "unparse")))

--- a/Lambda-list/ensure-proper.lisp
+++ b/Lambda-list/ensure-proper.lisp
@@ -4,7 +4,7 @@
 
 (defmethod ensure-proper ((lambda-list atom-cst))
   (if (null lambda-list)
-      (make-instance 'atom-cst :raw nil)
+      lambda-list
       (list (make-instance 'atom-cst :raw '&rest)
             lambda-list)))
 

--- a/Lambda-list/unparse.lisp
+++ b/Lambda-list/unparse.lisp
@@ -1,0 +1,101 @@
+(in-package #:concrete-syntax-tree)
+
+;;;; This file defines an "unparsing" system. Given a parsed lambda list, a
+;;;; lambda list intended for human consumption is returned. The unparse
+;;;; should resemble the originally parsed lambda list, but there is no
+;;;; exactness requirement.
+;;;; This is useful for displaying lambda lists to a user,
+;;;; for example in error reports.
+
+(defgeneric unparse-lambda-list (client lambda-list))
+
+(defgeneric unparse-parameter-group (client parameter-group))
+
+(defgeneric unparse-parameter (client parameter))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Methods
+
+(defmethod unparse-lambda-list (client (lambda-list lambda-list-type))
+  (loop for parameter-group in (children lambda-list)
+        appending (unparse-parameter-group client parameter-group)))
+
+;;;
+
+(defmethod unparse-parameter-group
+    (client (parameter-group singleton-parameter-group))
+  `(,(raw (name (keyword parameter-group)))
+    ,(unparse-parameter client (parameter parameter-group))))
+
+(defmethod unparse-parameter-group
+    (client (parameter-group implicit-parameter-group))
+  (loop for parameter in (parameters parameter-group)
+        collect (unparse-parameter client parameter)))
+
+(defmethod unparse-parameter-group
+    (client (parameter-group explicit-multi-parameter-group))
+  `(,(raw (name (keyword parameter-group)))
+    ,@(loop for parameter in (parameters parameter-group)
+            collect (unparse-parameter client parameter))))
+
+(defmethod unparse-parameter-group
+    (client (parameter-group key-parameter-group))
+  `(,(raw (name (keyword parameter-group)))
+    ,@(loop for parameter in (parameters parameter-group)
+            collect (unparse-parameter client parameter))
+    ,@(when (allow-other-keys parameter-group) '(&allow-other-keys))))
+
+;;; &aux parameters don't affect parsing errors, so we skip them.
+(defmethod unparse-parameter-group
+    (client (parameter-group aux-parameter-group))
+  (declare (ignore client))
+  nil)
+
+;;;
+
+(defmethod unparse-parameter (client (parameter simple-variable))
+  (declare (ignore client))
+  (raw (name parameter)))
+
+;;; Since unparsing is basically used for error reports at runtime,
+;;; the specializer is probably not relevant.
+(defmethod unparse-parameter (client (parameter specialized-required-parameter))
+  (declare (ignore client))
+  (raw (name parameter)))
+
+(defmethod unparse-parameter (client (parameter ordinary-optional-parameter))
+  (declare (ignore client))
+  (raw (name parameter)))
+
+(defmethod unparse-parameter
+    (client (parameter generic-function-optional-parameter))
+  (declare (ignore client))
+  (raw (name parameter)))
+
+(defmethod unparse-parameter (client (parameter ordinary-key-parameter))
+  (declare (ignore client))
+  (let ((rname (raw (name parameter)))
+        (rkeyword (raw (keyword parameter))))
+    (if (and (keywordp rkeyword)
+             (string= (symbol-name rname) (symbol-name rkeyword)))
+        ;; The keyword corresponds to the variable, so they don't
+        ;; both need to be in the unparse.
+        rname
+        ;; The keyword was custom.
+        `((,rkeyword ,rname)))))
+
+(defmethod unparse-parameter (client (parameter aux-parameter))
+  (declare (ignore client))
+  (raw (name parameter)))
+
+(defmethod unparse-parameter
+    (client (parameter destructuring-optional-parameter))
+  (unparse-lambda-list client (name parameter)))
+
+(defmethod unparse-parameter (client (parameter destructuring-key-parameter))
+  `((,(raw (keyword parameter))
+     ,(unparse-lambda-list client (name parameter)))))
+
+(defmethod unparse-parameter (client (parameter destructuring-lambda-list))
+  (unparse-lambda-list client parameter))

--- a/packages.lisp
+++ b/packages.lisp
@@ -182,6 +182,8 @@
            #:required-parameter-bindings
            #:required-parameters-bindings
            #:whole-parameter-bindings
+           #:too-many-arguments-error #:too-few-arguments-error
+           #:odd-keywords-error #:unknown-keywords-error
            #:parse-macro
            #:db
            #:valid-binding-p

--- a/packages.lisp
+++ b/packages.lisp
@@ -136,6 +136,8 @@
            #:parse-define-method-combination-lambda-list
            #:parse-destructuring-lambda-list
            #:parse-macro-lambda-list
+           #:unparse-lambda-list
+           #:unparse-parameter-group #:unparse-parameter
            #:target
            #:*ordinary-required-parameter-group*
            #:*ordinary-optional-parameter-group*


### PR DESCRIPTION
- improves error messages to be more detailed than "too many arguments", including e.g. the lambda list, arguments, and macro name
- signals errors when there are problems with &key parameters
- defines new generic functions that can be specialized to customize how errors are reported