### PR TITLE
Handle destructuring &whole parameters

### DIFF
--- a/Destructuring/parse-macro.lisp
+++ b/Destructuring/parse-macro.lisp
@@ -23,9 +23,10 @@
          (*current-macro-name* raw-name) 
 	 (env-var (find-var parsed-lambda-list 'environment-parameter-group))
 	 (final-env-var (if (cl:null env-var) (gensym "ENV") env-var))
-	 (form-var (find-var parsed-lambda-list 'whole-parameter-group))
-	 (final-form-var (if (cl:null form-var) (gensym "WHOLE") form-var))
+         (form-var (gensym "WHOLE"))
          (children (children parsed-lambda-list))
+         (toplevel-whole-group
+           (find-if (lambda (x) (typep x 'whole-parameter-group)) children))
          (relevant-children
            (remove-if (lambda (x) (typep x 'environment-parameter-group))
                       (remove-if (lambda (x) (typep x 'whole-parameter-group))
@@ -33,31 +34,31 @@
          (relevant-lambda-list
            (make-instance 'cst:macro-lambda-list :children relevant-children))
 	 (args-var (gensym)))
-    (multiple-value-bind (bindings ignorables)
+    (multiple-value-bind (main-bindings main-ignorables)
         (destructuring-lambda-list-bindings
          client relevant-lambda-list args-var)
-      `(lambda (,final-form-var ,final-env-var)
-         (block ,raw-name
-           (let* ((,args-var (cdr ,final-form-var))
-                  ,@bindings
-                  ;; We rebind the whole and environment variables
-                  ;; here, so that any user declarations for them
-                  ;; are scoped, properly.
-                  ;; We do this AFTER the args-var binding so that
-                  ;; if, e.g., a &whole is declared ignore, the
-                  ;; compiler does not complain that it was used
-                  ;; for the args-var binding.
-                  ,@(if (cl:null form-var)
-                        `()
-                        `((,final-form-var ,final-form-var)))
-                  (,final-env-var ,final-env-var))
-             (declare (ignorable ,@ignorables)
-                      ;; If the lambda list does not contain &environment, then
-                      ;; we IGNORE the GENSYMed parameter to avoid warnings.
-                      ;; If the lambda list does contain &environment, we do
-                      ;; not want to make it IGNORABLE because we would want a
-                      ;; warning if it is not used then.
-                      ,@(if (cl:null env-var)
-                            `((ignore ,final-env-var))
-                            `()))
-             ,@body))))))
+      ;; Any toplevel &WHOLE parameter is handled separately, because it
+      ;; starts with a different argument-variable.
+      (multiple-value-bind (whole-bindings whole-ignorables)
+          (if toplevel-whole-group
+              (parameter-group-bindings client toplevel-whole-group form-var)
+              (values nil nil))
+        `(lambda (,form-var ,final-env-var)
+           (block ,raw-name
+             (let* ((,args-var (cdr ,form-var))
+                    ,@whole-bindings
+                    ,@main-bindings
+                    ;; We rebind the environment variable here, so that any
+                    ;; user declarations for them are scoped, properly.
+                    (,final-env-var ,final-env-var))
+               (declare (ignorable ,@whole-ignorables ,@main-ignorables)
+                        ;; If the lambda list does not contain &environment,
+                        ;; then we IGNORE the GENSYMed parameter to avoid
+                        ;; warnings.
+                        ;; If the lambda list does contain &environment, we do
+                        ;; not want to make it IGNORABLE because we would want
+                        ;; a warning if it is not used then.
+                        ,@(if (cl:null env-var)
+                              `((ignore ,final-env-var))
+                              `()))
+               ,@body)))))))

--- a/Lambda-list/grammar-symbols.lisp
+++ b/Lambda-list/grammar-symbols.lisp
@@ -181,6 +181,18 @@
   (declare (ignore client))
   nil)
 
+(defclass ordinary-whole-parameter-group (whole-parameter-group)
+  ())
+
+;;; CLHS is somewhat self-contradictory about whether &whole parameters
+;;; destructure. The text in 3.4.4 refers to a &whole parameter as a
+;;; "single variable", but 3.4.4.1.2 describes it as a destructuring
+;;; pattern. The ANSI tests (which are not part of the standard)
+;;; expect destructuring &whole in the destructuring-bind.20 and
+;;; macrolet.36 tests. We do support &whole destructuring.
+(defclass destructuring-whole-parameter-group (whole-parameter-group)
+  ())
+
 ;;; This class is the root of all classes that correspond to
 ;;; individual parameters.  Instance of (subclasses of) this class are
 ;;; handled by the scanner.

--- a/Lambda-list/standard-grammars.lisp
+++ b/Lambda-list/standard-grammars.lisp
@@ -82,19 +82,24 @@
      (? ordinary-optional-parameter-group)
      (? ordinary-rest-parameter-group))))
 
-(defparameter *whole-parameter-group*
-  '((whole-parameter-group <-
+(defparameter *ordinary-whole-parameter-group*
+  '((ordinary-whole-parameter-group <-
      keyword-whole
      simple-variable)))
 
 (defparameter *define-method-combination-lambda-list*
   '((define-method-combination-lambda-list <-
-     (? whole-parameter-group)
+     (? ordinary-whole-parameter-group)
      ordinary-required-parameter-group
      (? ordinary-optional-parameter-group)
      (? ordinary-rest-parameter-group)
      (? ordinary-key-parameter-group)
      (? aux-parameter-group))))
+
+(defparameter *destructuring-whole-parameter-group*
+  '((destructuring-whole-parameter-group <-
+     keyword-whole
+     destructuring-parameter)))
 
 (defparameter *destructuring-required-parameter-group*
   '((destructuring-required-parameter-group <-
@@ -121,7 +126,7 @@
 
 (defparameter *destructuring-lambda-list*
   `((destructuring-lambda-list <-
-     (? whole-parameter-group)
+     (? destructuring-whole-parameter-group)
      destructuring-required-parameter-group
      (? ordinary-optional-parameter-group)
      (? destructuring-rest-parameter-group)
@@ -130,7 +135,7 @@
 
 (defparameter *macro-lambda-list*
   `((macro-lambda-list <-
-     (? whole-parameter-group)
+     (? destructuring-whole-parameter-group)
      (? environment-parameter-group)
      destructuring-required-parameter-group
      (? environment-parameter-group)
@@ -158,8 +163,9 @@
 	  *environment-parameter-group*
           *defsetf-lambda-list*
           *define-modify-macro-lambda-list*
-	  *whole-parameter-group*
+	  *ordinary-whole-parameter-group*
           *define-method-combination-lambda-list*
+          *destructuring-whole-parameter-group*
           *destructuring-required-parameter-group*
           *destructuring-optional-parameter-group*
           *destructuring-key-parameter-group*

--- a/packages.lisp
+++ b/packages.lisp
@@ -91,7 +91,8 @@
            #:ordinary-rest-parameter-group
            #:destructuring-rest-parameter-group
            #:environment-parameter-group
-           #:whole-parameter-group
+           #:ordinary-whole-parameter-group
+           #:destructuring-whole-parameter-group
            #:parameter
            #:parameters
            #:children


### PR DESCRIPTION
I am not sure if define-method-combination argument lambda lists should have destructuring whole parameters or not. My guess is no, because they "are similar to ordinary lambda lists" and there's no
special mention of destructuring. But it wouldn't be too hard to change our behavior if I'm wrong.

Also, to be extra clear: My earlier "destructuring whole" PR was to allow using `&whole` below top level in macro lambda list. This PR is to allow a `&whole` parameter at any level to be a destructuring lambda list, like e.g. `(&whole (op x y) z w)`.