### PR TITLE
Treat warnings for unused variables

### DIFF
--- a/Destructuring/rest-parameters.lisp
+++ b/Destructuring/rest-parameters.lisp
@@ -2,6 +2,7 @@
 
 (defmethod rest-parameter-bindings
     (client (parameter simple-variable) argument-variable)
+  (declare (ignore client))
   `((,(raw (name parameter)) ,argument-variable)))
 
 (defmethod rest-parameter-bindings

--- a/Destructuring/whole-parameters.lisp
+++ b/Destructuring/whole-parameters.lisp
@@ -2,6 +2,7 @@
 
 (defmethod whole-parameter-bindings
     (client (parameter simple-variable) argument-variable)
+  (declare (ignore client))
   `((,(raw (name parameter)) ,argument-variable)))
 
 (defmethod whole-parameter-bindings

--- a/Lambda-list/scanner-action.lisp
+++ b/Lambda-list/scanner-action.lisp
@@ -22,6 +22,7 @@
 (defgeneric scanner-action (client item lambda-list terminal input))
 
 (defmethod scanner-action (client item lambda-list terminal input)
+  (declare (ignore client item lambda-list terminal input))
   '())
 
 (defun advance-dot-position (item parse-tree)


### PR DESCRIPTION
Am trying to have the build process of clasp free of compiler warnings (to be able to see real problems). 

The only changes are various `(declare (ignore ..))` so they should be safe.

For testing i build clasp with this branch, run the regression-tests and also the ansi-tests with no regressions.