### PR TITLE
Add optional source parameter for cst-to-expression

### DIFF
--- a/cst-from-expression.lisp
+++ b/cst-from-expression.lisp
@@ -2,26 +2,29 @@
 
 (defvar *table*)
 
-(defun cst-from-element (expression)
+(defun cst-from-element (expression source)
   (cond ((cl:atom expression)
          (make-instance 'atom-cst
-           :raw expression))
+           :raw expression
+           :source source))
         (t
-         (cst-from-list-expression expression))))
+         (cst-from-list-expression expression source))))
 
-(defun cst-from-list-expression (expression)
+(defun cst-from-list-expression (expression source)
   (cond ((nth-value 1 (gethash expression *table*))
          (gethash expression *table*))
         ((cl:atom expression)
          (make-instance 'atom-cst
-           :raw expression))
+           :raw expression
+           :source source))
         (t
-         (let ((result (make-instance 'cons-cst :raw expression)))
+         (let ((result (make-instance 'cons-cst
+                         :raw expression :source source)))
            (setf (gethash expression *table*) result)
            (reinitialize-instance result
-              :first (cst-from-element (car expression))
-              :rest (cst-from-list-expression (cdr expression)))))))
+              :first (cst-from-element (car expression) source)
+              :rest (cst-from-list-expression (cdr expression) source))))))
 
-(defun cst-from-expression (expression)
+(defun cst-from-expression (expression &key source)
   (let ((*table* (make-hash-table :test #'eq)))
-    (cst-from-element expression)))
+    (cst-from-element expression source)))


### PR DESCRIPTION
This is useful to preserve source information when constructing CSTs in for example Cleavir.

Alternately it could be a keyword parameter.