### PR TITLE
Add quasiquotation mechanism

### DIFF
--- a/Test/packages.lisp
+++ b/Test/packages.lisp
@@ -8,4 +8,5 @@
 (defun run-tests ()
   (test-cst-from-expression)
   (test-reconstruct)
-  (test-reconstruct-1))
+  (test-reconstruct-1)
+  (test-quasiquotation))

--- a/Test/quasiquotation.lisp
+++ b/Test/quasiquotation.lisp
@@ -1,0 +1,17 @@
+(cl:in-package #:concrete-syntax-tree-test)
+
+(defun test-quasiquotation ()
+  (let* ((cst1 (cst:cst-from-expression 'a))
+         (cst2 (cst:cst-from-expression '(b c)))
+         (source (gensym))
+         (qq (cst:quasiquote source
+               (d (cst:unquote cst1) (cst:unquote-splicing cst2)
+                  (cst:unquote cst2) (e (f f) . g)
+                  (cst:unquote-splicing (cl:list cst1 cst1))
+                  ((cst:unquote cst1) . (cst:unquote cst1))))))
+    (assert (equal (cst:raw qq) '(d a b c (b c) (e (f f) . g) a a (a . a))))
+    (assert (eq (cst:source qq) source))
+    (assert (eq (cst:second qq) cst1))
+    (assert (eq (cst:fifth qq) cst2))
+    (assert (eq (cst:first (cst:ninth qq)) cst1))
+    (assert (eq (cst:rest (cst:ninth qq)) cst1))))

--- a/concrete-syntax-tree-base.asd
+++ b/concrete-syntax-tree-base.asd
@@ -23,6 +23,7 @@
    (:file "listify")
    (:file "cstify")
    (:file "cst-from-expression")
+   (:file "quasiquotation")
    (:file "reconstruct")
    (:file "declarations")
    (:file "body")

--- a/concrete-syntax-tree.asd
+++ b/concrete-syntax-tree.asd
@@ -12,6 +12,7 @@
   :components ((:file "packages")
                (:file "random-expression")
                (:file "cst-from-expression")
+               (:file "quasiquotation")
                (:file "random-sources")
                (:file "reconstruct"))
   :perform (test-op (operation component)

--- a/condition-reporters-english.lisp
+++ b/condition-reporters-english.lisp
@@ -10,3 +10,12 @@
     ((condition cons-cst-required) stream (language acclimation:english))
   (format stream "~@<Encountered ~S where a ~A is required.~@:>"
           (cst condition) 'cons-cst))
+
+(defmethod acclimation:report-condition
+    ((condition unquote-splicing-in-dotted-list) stream
+     (language acclimation:english))
+  (format stream "Splicing unquote at end of list (like a . ,@b)."))
+
+(defmethod acclimation:report-condition
+    ((condition unquote-splicing-at-top) stream (language acclimation:english))
+  (format stream "Splicing unquote as quasiquotation form (like `,@foo)."))

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -12,3 +12,8 @@
 ;;; CONS-CST was required, but something else was given.
 (define-condition cons-cst-required (cst-error)
   ((%cst :initarg :cst :reader cst)))
+
+(define-condition unquote-error (error) ())
+
+(define-condition unquote-splicing-in-dotted-list (unquote-error) ())
+(define-condition unquote-splicing-at-top (unquote-error) ())

--- a/cstify.lisp
+++ b/cstify.lisp
@@ -1,11 +1,12 @@
 (cl:in-package #:concrete-syntax-tree)
 
-(defmethod cstify ((list cl:null))
-  (make-instance 'atom-cst :raw nil))
+(defmethod cstify ((list cl:null) &key source)
+  (make-instance 'atom-cst :raw nil :source source))
 
-(defmethod cstify ((list cl:cons))
+(defmethod cstify ((list cl:cons) &key source)
   (let ((rest (cstify (cdr list))))
     (make-instance 'cons-cst
       :first (car list)
       :rest rest
+      :source source
       :raw (cl:cons (raw (car list)) (raw rest)))))

--- a/generic-functions.lisp
+++ b/generic-functions.lisp
@@ -32,7 +32,7 @@
 
 ;;; Given an ordinary proper Common Lisp list of CSTs, return a CST,
 ;;; the elements of which are the CSTs of the input.
-(defgeneric cstify (list))
+(defgeneric cstify (list &key source))
 
 ;;; Given a body in the form of a CST that may contain declarations
 ;;; but not a documentation string, return two values

--- a/packages.lisp
+++ b/packages.lisp
@@ -199,4 +199,7 @@
            #:?
            #:<-
            #:lambda-list-keyword
-           #:lambda-list-type))
+           #:lambda-list-type)
+  (:export #:quasiquote #:unquote #:unquote-splicing
+           #:unquote-error
+           #:unquote-splicing-in-dotted-list #:unquote-splicing-at-top))

--- a/quasiquotation.lisp
+++ b/quasiquotation.lisp
@@ -1,0 +1,78 @@
+(in-package #:concrete-syntax-tree)
+
+;;;; The QUASIQUOTE operator allows concrete syntax trees to be constructed in
+;;;; a manner analogous to list quasiquotation (backquote).
+;;;; The syntax is (QUASIQUOTE source template), where
+;;;; template := atom
+;;;;             | (UNQUOTE form-yielding-cst)
+;;;;             | (template . template)
+;;;;             | ((UNQUOTE-SPLICING form-yielding-list-cst-or-list)
+;;;;                . template)
+;;;; Unquotation means the CST yielded by a form will be inserted.
+;;;; Splicing unquotation accepts both list CSTs
+;;;; (i.e. CSTs suitable for LISTIFY) and lists of CSTs.
+;;;; Atoms are made into ATOM-CSTs.
+;;;; All CSTs created by quasiquotation will have the given source (evaluated)
+;;;; as their source.
+;;;; Note that unlike CL quasiquotation, vector templates are not allowed, as
+;;;; there are no vector CSTs. Vectors in templates will be treated as atoms
+;;;; and wrapped in CSTs without processing of the elements.
+;;;; There is no equivalent to ,.
+
+(defun %quote (source atom) (make-instance 'atom-cst :raw atom :source source))
+
+(defun %append2 (source x y)
+  (etypecase x
+    (atom-cst y) ; could check that X is really NIL
+    (cons-cst (cons (first x) (%append2 source (rest x) y) :source source))
+    (cl:null y)
+    (cl:cons
+     (cons (cl:first x) (%append2 source (cl:rest x) y) :source source))))
+
+(defun %append (source &rest list-csts-and-lists)
+  (cond ((cl:null list-csts-and-lists) (%quote source nil))
+        ((cl:null (cl:rest list-csts-and-lists))
+         (cl:first list-csts-and-lists))
+        (t (%append2 source (cl:first list-csts-and-lists)
+                     (apply #'%append source (cl:rest list-csts-and-lists))))))
+
+(defun transform (sourcef form)
+  (typecase form
+    ;; We can use CL:LIST instead of building a CST because TRANSFORM always
+    ;; returns a form used as a non-final argument to %APPEND.
+    (cl:atom `(cl:list (%quote ,sourcef ',form)))
+    ((cl:cons (eql unquote)) `(cl:list ,(cl:second form)))
+    ((cl:cons (eql unquote-splicing)) (cl:second form))
+    (t `(cl:list ,(appender sourcef form)))))
+
+(defun transform-compound (sourcef object)
+  (labels ((rec (object)
+             (typecase object
+               ((cl:cons t cl:atom) ; (a . b)
+                (cl:list (transform sourcef (cl:car object))
+                         `(%quote ,sourcef ',(cl:cdr object))))
+               ((cl:cons t (cl:cons (eql unquote))) ; (a . ,b)
+                (cl:list (transform sourcef (cl:car object))
+                         (cl:second (cl:cdr object))))
+               ((cl:cons t (cl:cons (eql unquote-splicing))) ; (a . ,@b)
+                (error 'unquote-splicing-in-dotted-list))
+               (t (cl:list* (transform sourcef (cl:car object))
+                            (rec (cl:cdr object)))))))
+    (rec object)))
+
+(defun appender (sourcef argument)
+  ;; We could do some optimization here - transforming to a %LIST*, etc.
+  `(%append ,sourcef ,@(transform-compound sourcef argument)))
+
+(defun transform-qq-argument (sourcef argument)
+  (if (cl:atom argument)
+      `(%quote ,sourcef ',argument)
+      (case (cl:car argument)
+        ((unquote) (cl:second argument))
+        ((unquote-splicing) (error 'unquote-splicing-at-top))
+        (t (appender sourcef argument)))))
+
+(defmacro quasiquote (sourcef argument)
+  (let ((gsource (gensym "SOURCE")))
+    `(let ((,gsource ,sourcef))
+       ,(transform-qq-argument gsource argument))))


### PR DESCRIPTION
This is useful for "macros" that operate on the CST level. We don't have any kind of user mechanism for those anywhere, but something similar is used in some places in Cleavir, e.g. the definition of `let*`.